### PR TITLE
Generate asp.bin to be able to copy board directly (USB mass storage)

### DIFF
--- a/workspace/makefiles_common/Makefile.asp3
+++ b/workspace/makefiles_common/Makefile.asp3
@@ -115,7 +115,8 @@ TECSGEN = ruby $(TECSDIR)/tecsgen.rb
 #
 #  オブジェクトファイル名の定義
 #
-OBJNAME = asp.elf
+OBJNAME = asp
+OBJEXT = elf
 ifdef OBJEXT
 	OBJFILE = $(OBJNAME).$(OBJEXT)
 	CFG1_OUT = cfg1_out.$(OBJEXT)
@@ -223,12 +224,12 @@ endif
 .PHONY: all
 ifndef OMIT_TECS
 all: tecs
-	@$(MAKE) check
-#	@$(MAKE) check $(OBJNAME).bin
+#	@$(MAKE) check
+	@$(MAKE) check $(OBJNAME).bin
 #	@$(MAKE) check $(OBJNAME).srec
 else
-all: check
-#all: check $(OBJNAME).bin
+#all: check
+all: check $(OBJNAME).bin
 #all: check $(OBJNAME).srec
 endif
 


### PR DESCRIPTION
asp.bin を生成するようにしました．
USBマスストレージとして見えているボードに直接コピるだけで動かせるようになります．

なおASPについては同じ方法でも難しそうです．領域のサイズが大きくなるようで "No space left on device" となってしまいます．