### PR TITLE
move `__dso_handle` from mros2/

### DIFF
--- a/src/startup/dso_handle.c
+++ b/src/startup/dso_handle.c
@@ -1,0 +1,2 @@
+/* Statement to avoid link error */
+void* __dso_handle=0;


### PR DESCRIPTION
Since the definition of `__dso_handle`, originally defined in `mros2` repository,  was specific to the target about `mros2-asp3-f767zi` (mros2 with TOPPERS/ASP3 kernel and STM32CubeMX lib), we decided to move this definition to `mros2-asp3-f767zi` repository from `mros2`.

also see:
https://github.com/mROS-base/mros2/pull/22