### PR TITLE
Enhance README and application

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,7 @@
       "type": "shell",
       "command": "make",
       "args": [
-        "app=echoreply_string"
+        "app=mturtle_teleop"
       ],
       "options": {
         "env": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,7 @@
       "type": "shell",
       "command": "make",
       "args": [
-        "app=mturtle_teleop"
+        "app=echoreply_string"
       ],
       "options": {
         "env": {

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Please also check [mros2 repository](https://github.com/mROS-base/mros2) for mor
 
 ## Quickstart
 
-This section explains how to build and execute mROS 2 with TOPPERS/ASP3 kernel, using `echoback_reply` application as an example.
+This section explains how to build and execute mROS 2 with TOPPERS/ASP3 kernel, using `echoreply_string` application as an example.
 
 This example only uses a built-in-type (`string` a.k.a `std_msgs::msg::String`), so you can skip the generation of header files for custom msg types. Please see [Generating header files for custom MsgTypes](#generating-header-files-for-custom-msgtypes) for more detail.
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ Please also check [mros2 repository](https://github.com/mROS-base/mros2) for mor
       1. Install [STM32CubeIDE v1.5.0](https://www.st.com/en/development-tools/stm32cubeide.html#overview&secondary=st-get-software). It contains v7.3.1 cross-compiler.
       If you did not change the default location to be installed, `$PATH` to be set will be _/opt/st/stm32cubeide_1.5.0/plugins/com.st.stm32cube.ide.mcu.externaltools.gnu-tools-for-stm32.7-2018-q2-update.linux64_1.5.0.202011040924/tools_
     - Currently, we confirmed issue that v6.3.1 (which will be installed via `apt`) cannot be operated successfully. See also [#36](https://github.com/mROS-base/mros2-asp3-f767zi/issues/36).
-1. Connet the board and the host with LAN cable and micro-USB cable (CN1 connector on the board, opposite side of LAN connector). Please set the IP address and Netmask of the host to `192.168.11.3` and `255.255.255.0`, respectively.
-    - You can also connect the network with the board through the router when you can set the IP and Netmask as the above.
+1. Connet the board and the host with LAN cable and micro-USB cable (CN1 connector on the board, opposite side of LAN connector). Please set the IP address and Netmask of the host to `192.168.11.x` and `255.255.255.0`, respectively.
     - The IP address of the board will be assigned to `192.168.11.2`. If you want to change the IP settings, you need to modify [src/config/lwip.c](https://github.com/mROS-base/mros2-asp3-f767zi/blob/main/src/config/lwip.c#L69-L80) and [embeddedRTPS/include/rtps/config.h](https://github.com/mROS-base/embeddedRTPS/blob/mros2/include/rtps/config.h#L37) as you want.
+    - You can also connect the network with the board through the router when you can set the IP and Netmask as the above.
+    - The firewall on the host (Ubuntu) needs to be disabled for ROS 2 (DDS) communication (e.g. `$ sudo ufw disable`)
+    - If the host is connected to the Internet other than wired network (e.g., Wi-Fi), communication with mros2 may not work properly. In that case, please turn off them.
 
 ## Quickstart
 

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -20,7 +20,8 @@ $ make app=pub_float32
 - [pub_twist](pub_twist/)
 - [sub_pose](sub_pose/)
 - [mturtle_teleop](mturtle_teleop/)
-- [custom_msgs/](custom_msgs/): definition and header files for custom MsgTypes (see [detail](../README.md#generating-header-files-for-custom-msgtypes))
+
+[custom_msgs/](custom_msgs/) contains the definition files and header files for custom MsgTypes. See [detail about generating header files for custom MsgTypes](../README.md#generating-header-files-for-custom-msgtypes).
 
 ## Corresponding examples on the host
 

--- a/workspace/echoreply_string/app.cpp
+++ b/workspace/echoreply_string/app.cpp
@@ -27,7 +27,7 @@ int main(int argc, char * argv[])
   pub = node.create_publisher<std_msgs::msg::String>("to_linux", 10);
   sub = node.create_subscription<std_msgs::msg::String>("to_stm", 10, userCallback);
   std_msgs::msg::String msg;
-
+  osDelay(100);
   MROS2_INFO("ready to pub/sub message");
 
   mros2::spin();

--- a/workspace/pub_float32/app.cpp
+++ b/workspace/pub_float32/app.cpp
@@ -15,6 +15,7 @@ int main(int argc, char *argv[])
 
   mros2::Node node = mros2::Node::create_node("mros2_node");
   mros2::Publisher pub = node.create_publisher<std_msgs::msg::Float32>("to_linux", 10);
+  osDelay(100);
   MROS2_INFO("ready to pub/sub message");
 
   std_msgs::msg::Float32 msg;

--- a/workspace/pub_twist/app.cpp
+++ b/workspace/pub_twist/app.cpp
@@ -15,7 +15,8 @@ int main(int argc, char * argv[])
   BSP_LED_Toggle(LED1);
 
   mros2::Node node = mros2::Node::create_node("pub_twist");
-  mros2::Publisher pub = node.create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 10);  
+  mros2::Publisher pub = node.create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 10);
+  osDelay(100);
   MROS2_INFO("ready to pub/sub message");
 
   geometry_msgs::msg::Vector3 linear;

--- a/workspace/sub_pose/app.cpp
+++ b/workspace/sub_pose/app.cpp
@@ -20,7 +20,7 @@ int main(int argc, char * argv[])
 
   mros2::Node node = mros2::Node::create_node("sub_pose");
   mros2::Subscriber sub = node.create_subscription<geometry_msgs::msg::Pose>("cmd_vel", 10, userCallback);
-  
+  osDelay(100);
   MROS2_INFO("ready to pub/sub message");
 
   mros2::spin();

--- a/workspace/sub_uint16/app.cpp
+++ b/workspace/sub_uint16/app.cpp
@@ -20,7 +20,7 @@ int main(int argc, char * argv[])
 
   mros2::Node node = mros2::Node::create_node("mros2_node");
   mros2::Subscriber sub = node.create_subscription<std_msgs::msg::UInt16>("to_stm", 10, userCallback);
-
+  osDelay(100);
   MROS2_INFO("ready to pub/sub message");
 
   mros2::spin();


### PR DESCRIPTION
- some fixes to README
- insert `osDelay(100)` to wait create_publisher/_subscription
  - The process of create_publisher and _subscription, which are executed concurrently as a system task, takes a little time. So I want to wait them by inserting `osDelay(100)` after them in app.cfg.